### PR TITLE
Generate create, delete and setter for Route

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-11-17T22:45:36Z"
+  build_date: "2021-11-18T00:17:24Z"
   build_hash: 966e9a9ac6dfb4bbc2d3ded1972ce2b706391d44
-  go_version: go1.17
+  go_version: go1.17.1
   version: v0.15.2
 api_directory_checksum: e13129556d60164826bdeea39735660c7cfa1212
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: 9909796f8b2f4f236120776f311f46f1e3859462
+  file_checksum: c181a37589ac5c979a81e499c2561dbd69264368
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -11,6 +11,7 @@ ignore:
     - CreateTransitGatewayInput.DryRun
     - CreateVpcInput.DryRun
     - CreateVpcEndpointInput.DryRun
+    - DeleteRouteInput.DryRun
     # support EC2-VPC only
     - DeleteSecurityGroupInput.GroupName
   resource_names:

--- a/generator.yaml
+++ b/generator.yaml
@@ -11,6 +11,7 @@ ignore:
     - CreateTransitGatewayInput.DryRun
     - CreateVpcInput.DryRun
     - CreateVpcEndpointInput.DryRun
+    - DeleteRouteInput.DryRun
     # support EC2-VPC only
     - DeleteSecurityGroupInput.GroupName
   resource_names:

--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -150,7 +150,7 @@ func (rm *resourceManager) createRoute(
 	exit := rlog.Trace("rm.createRoute")
 	defer exit(err)
 
-	input := rm.newCreateRoutePayload(r, c)
+	input := rm.newCreateRouteInput(c)
 	_, err = rm.sdkapi.CreateRouteWithContext(ctx, input)
 	rm.metrics.RecordAPICall("CREATE", "CreateRoute", err)
 	return err
@@ -165,79 +165,10 @@ func (rm *resourceManager) deleteRoute(
 	exit := rlog.Trace("rm.deleteRoute")
 	defer exit(err)
 
-	input := rm.newDeleteRoutePayload(r, c)
+	input := rm.newDeleteRouteInput(c)
 	_, err = rm.sdkapi.DeleteRouteWithContext(ctx, input)
 	rm.metrics.RecordAPICall("DELETE", "DeleteRoute", err)
 	return err
-}
-
-func (rm *resourceManager) newCreateRoutePayload(
-	r *resource,
-	c svcapitypes.CreateRouteInput,
-) *svcsdk.CreateRouteInput {
-	input := &svcsdk.CreateRouteInput{}
-	if r.ko.Status.RouteTableID != nil {
-		input.SetRouteTableId(*r.ko.Status.RouteTableID)
-	}
-	if c.CarrierGatewayID != nil {
-		input.SetCarrierGatewayId(*c.CarrierGatewayID)
-	}
-	if c.DestinationCIDRBlock != nil {
-		input.SetDestinationCidrBlock(*c.DestinationCIDRBlock)
-	}
-	if c.DestinationIPv6CIDRBlock != nil {
-		input.SetDestinationIpv6CidrBlock(*c.DestinationIPv6CIDRBlock)
-	}
-	if c.DestinationPrefixListID != nil {
-		input.SetDestinationPrefixListId(*c.DestinationPrefixListID)
-	}
-	if c.EgressOnlyInternetGatewayID != nil {
-		input.SetEgressOnlyInternetGatewayId(*c.EgressOnlyInternetGatewayID)
-	}
-	if c.GatewayID != nil {
-		input.SetGatewayId(*c.GatewayID)
-	}
-	if c.InstanceID != nil {
-		input.SetInstanceId(*c.InstanceID)
-	}
-	if c.LocalGatewayID != nil {
-		input.SetLocalGatewayId(*c.LocalGatewayID)
-	}
-	if c.NATGatewayID != nil {
-		input.SetNatGatewayId(*c.NATGatewayID)
-	}
-	if c.NetworkInterfaceID != nil {
-		input.SetNetworkInterfaceId(*c.NetworkInterfaceID)
-	}
-	if c.TransitGatewayID != nil {
-		input.SetTransitGatewayId(*c.TransitGatewayID)
-	}
-	if c.VPCPeeringConnectionID != nil {
-		input.SetVpcPeeringConnectionId(*c.VPCPeeringConnectionID)
-	}
-
-	return input
-}
-
-func (rm *resourceManager) newDeleteRoutePayload(
-	r *resource,
-	c svcapitypes.CreateRouteInput,
-) *svcsdk.DeleteRouteInput {
-	input := &svcsdk.DeleteRouteInput{}
-	if r.ko.Status.RouteTableID != nil {
-		input.SetRouteTableId(*r.ko.Status.RouteTableID)
-	}
-	if c.DestinationCIDRBlock != nil {
-		input.SetDestinationCidrBlock(*c.DestinationCIDRBlock)
-	}
-	if c.DestinationIPv6CIDRBlock != nil {
-		input.SetDestinationIpv6CidrBlock(*c.DestinationIPv6CIDRBlock)
-	}
-	if c.DestinationPrefixListID != nil {
-		input.SetDestinationPrefixListId(*c.DestinationPrefixListID)
-	}
-
-	return input
 }
 
 func (rm *resourceManager) customUpdateRouteTable(
@@ -284,50 +215,7 @@ func (rm *resourceManager) addRoutesToStatus(
 	if routeTable.Routes != nil {
 		routesInStatus := []*svcapitypes.Route{}
 		for _, r := range routeTable.Routes {
-			routeInStatus := &svcapitypes.Route{}
-			if r.CarrierGatewayId != nil {
-				routeInStatus.CarrierGatewayID = r.CarrierGatewayId
-			}
-			if r.DestinationCidrBlock != nil {
-				routeInStatus.DestinationCIDRBlock = r.DestinationCidrBlock
-			}
-			if r.DestinationIpv6CidrBlock != nil {
-				routeInStatus.DestinationIPv6CIDRBlock = r.DestinationIpv6CidrBlock
-			}
-			if r.DestinationPrefixListId != nil {
-				routeInStatus.DestinationPrefixListID = r.DestinationPrefixListId
-			}
-			if r.EgressOnlyInternetGatewayId != nil {
-				routeInStatus.EgressOnlyInternetGatewayID = r.EgressOnlyInternetGatewayId
-			}
-			if r.GatewayId != nil {
-				routeInStatus.GatewayID = r.GatewayId
-			}
-			if r.InstanceId != nil {
-				routeInStatus.InstanceID = r.InstanceId
-			}
-			if r.LocalGatewayId != nil {
-				routeInStatus.LocalGatewayID = r.LocalGatewayId
-			}
-			if r.NatGatewayId != nil {
-				routeInStatus.NATGatewayID = r.NatGatewayId
-			}
-			if r.NetworkInterfaceId != nil {
-				routeInStatus.NetworkInterfaceID = r.NetworkInterfaceId
-			}
-			if r.TransitGatewayId != nil {
-				routeInStatus.TransitGatewayID = r.TransitGatewayId
-			}
-			if r.VpcPeeringConnectionId != nil {
-				routeInStatus.VPCPeeringConnectionID = r.VpcPeeringConnectionId
-			}
-			if r.Origin != nil {
-				routeInStatus.Origin = r.Origin
-			}
-			if r.State != nil {
-				routeInStatus.State = r.State
-			}
-			routesInStatus = append(routesInStatus, routeInStatus)
+			routesInStatus = append(routesInStatus, rm.setResourceRoute(r))
 		}
 		ko.Status.RouteStatuses = routesInStatus
 	}

--- a/pkg/resource/route_table/sdk.go
+++ b/pkg/resource/route_table/sdk.go
@@ -720,3 +720,131 @@ func compareCreateRouteInput(
 
 	return delta
 }
+
+func (rm *resourceManager) newCreateRouteInput(
+	c svcapitypes.CreateRouteInput,
+) *svcsdk.CreateRouteInput {
+	res := &svcsdk.CreateRouteInput{}
+
+	if c.CarrierGatewayID != nil {
+		res.SetCarrierGatewayId(*c.CarrierGatewayID)
+	}
+	if c.DestinationCIDRBlock != nil {
+		res.SetDestinationCidrBlock(*c.DestinationCIDRBlock)
+	}
+	if c.DestinationIPv6CIDRBlock != nil {
+		res.SetDestinationIpv6CidrBlock(*c.DestinationIPv6CIDRBlock)
+	}
+	if c.DestinationPrefixListID != nil {
+		res.SetDestinationPrefixListId(*c.DestinationPrefixListID)
+	}
+	if c.EgressOnlyInternetGatewayID != nil {
+		res.SetEgressOnlyInternetGatewayId(*c.EgressOnlyInternetGatewayID)
+	}
+	if c.GatewayID != nil {
+		res.SetGatewayId(*c.GatewayID)
+	}
+	if c.InstanceID != nil {
+		res.SetInstanceId(*c.InstanceID)
+	}
+	if c.LocalGatewayID != nil {
+		res.SetLocalGatewayId(*c.LocalGatewayID)
+	}
+	if c.NATGatewayID != nil {
+		res.SetNatGatewayId(*c.NATGatewayID)
+	}
+	if c.NetworkInterfaceID != nil {
+		res.SetNetworkInterfaceId(*c.NetworkInterfaceID)
+	}
+	if c.RouteTableID != nil {
+		res.SetRouteTableId(*c.RouteTableID)
+	}
+	if c.TransitGatewayID != nil {
+		res.SetTransitGatewayId(*c.TransitGatewayID)
+	}
+	if c.VPCEndpointID != nil {
+		res.SetVpcEndpointId(*c.VPCEndpointID)
+	}
+	if c.VPCPeeringConnectionID != nil {
+		res.SetVpcPeeringConnectionId(*c.VPCPeeringConnectionID)
+	}
+
+	return res
+}
+
+func (rm *resourceManager) newDeleteRouteInput(
+	c svcapitypes.CreateRouteInput,
+) *svcsdk.DeleteRouteInput {
+	res := &svcsdk.DeleteRouteInput{}
+
+	if c.DestinationCIDRBlock != nil {
+		res.SetDestinationCidrBlock(*c.DestinationCIDRBlock)
+	}
+	if c.DestinationIPv6CIDRBlock != nil {
+		res.SetDestinationIpv6CidrBlock(*c.DestinationIPv6CIDRBlock)
+	}
+	if c.DestinationPrefixListID != nil {
+		res.SetDestinationPrefixListId(*c.DestinationPrefixListID)
+	}
+	if c.RouteTableID != nil {
+		res.SetRouteTableId(*c.RouteTableID)
+	}
+
+	return res
+}
+
+// setRoute sets a resource Route type
+// given the SDK type.
+func (rm *resourceManager) setResourceRoute(
+	resp *svcsdk.Route,
+) *svcapitypes.Route {
+	res := &svcapitypes.Route{}
+
+	if resp.CarrierGatewayId != nil {
+		res.CarrierGatewayID = resp.CarrierGatewayId
+	}
+	if resp.DestinationCidrBlock != nil {
+		res.DestinationCIDRBlock = resp.DestinationCidrBlock
+	}
+	if resp.DestinationIpv6CidrBlock != nil {
+		res.DestinationIPv6CIDRBlock = resp.DestinationIpv6CidrBlock
+	}
+	if resp.DestinationPrefixListId != nil {
+		res.DestinationPrefixListID = resp.DestinationPrefixListId
+	}
+	if resp.EgressOnlyInternetGatewayId != nil {
+		res.EgressOnlyInternetGatewayID = resp.EgressOnlyInternetGatewayId
+	}
+	if resp.GatewayId != nil {
+		res.GatewayID = resp.GatewayId
+	}
+	if resp.InstanceId != nil {
+		res.InstanceID = resp.InstanceId
+	}
+	if resp.InstanceOwnerId != nil {
+		res.InstanceOwnerID = resp.InstanceOwnerId
+	}
+	if resp.LocalGatewayId != nil {
+		res.LocalGatewayID = resp.LocalGatewayId
+	}
+	if resp.NatGatewayId != nil {
+		res.NATGatewayID = resp.NatGatewayId
+	}
+	if resp.NetworkInterfaceId != nil {
+		res.NetworkInterfaceID = resp.NetworkInterfaceId
+	}
+	if resp.Origin != nil {
+		res.Origin = resp.Origin
+	}
+	if resp.State != nil {
+		res.State = resp.State
+	}
+	if resp.TransitGatewayId != nil {
+		res.TransitGatewayID = resp.TransitGatewayId
+	}
+	if resp.VpcPeeringConnectionId != nil {
+		res.VPCPeeringConnectionID = resp.VpcPeeringConnectionId
+	}
+
+	return res
+}

--- a/templates/hooks/route_table/sdk_file_end.go.tpl
+++ b/templates/hooks/route_table/sdk_file_end.go.tpl
@@ -20,7 +20,48 @@ func compare{{$memberRefName}} (
 	return delta
 }
 
+func (rm *resourceManager) new{{ $memberRefName }}(
+	c svcapitypes.{{ $memberRefName }},
+) *svcsdk.{{ $memberRefName }} {
+	res := &svcsdk.{{ $memberRefName }}{}
+
+{{ GoCodeSetSDKForStruct $CRD "" "res" $memberRef "" "c" 1 }}
+
+	return res
+}
+
 {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/* Delete operation for Routes */}}
+
+{{- $deleteInputRef := (index $SDKAPI.API.Operations "DeleteRoute").InputRef }}
+{{- $deleteInputName := $deleteInputRef.ShapeName }}
+
+func (rm *resourceManager) new{{ $deleteInputName }}(
+	c svcapitypes.CreateRouteInput,
+) *svcsdk.{{ $deleteInputName }} {
+	res := &svcsdk.{{ $deleteInputName }}{}
+
+{{ GoCodeSetSDKForStruct $CRD "" "res" $deleteInputRef "" "c" 1 }}
+
+	return res
+}
+
+{{/* Setter for Route */}}
+
+{{- $routeRef := (index (index $SDKAPI.API.Shapes "RouteTable").MemberRefs "Routes").Shape.MemberRef }}
+{{- $routeRefName := $routeRef.ShapeName }}
+
+// set{{ $routeRefName }} sets a resource {{ $routeRefName }} type
+// given the SDK type.
+func (rm *resourceManager) setResource{{ $routeRefName }}(
+    resp *svcsdk.{{ $routeRefName }},
+) *svcapitypes.{{ $routeRefName }} {
+    res := &svcapitypes.{{ $routeRefName }}{}
+
+{{ GoCodeSetResourceForStruct $CRD "RouteStatuses" "res" $routeRef "resp" $routeRef 1 }}
+    return res
+}


### PR DESCRIPTION
Added manually logic in the `sdk_file_end.go.tpl` files to fetch the shape refs for `CreateRouteInput` and `DeleteRouteInput` and generate the respective setters.

Also added a method to generate the setter for `Route` in the status, to remove some code duplication in the hook